### PR TITLE
fixed some issues loading cypress packages that don't have date and time...

### DIFF
--- a/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/instance/date.st
+++ b/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/instance/date.st
@@ -1,0 +1,3 @@
+*monticellofiletree-core
+date
+	^ date ifNil:[^Date today]

--- a/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/instance/time.st
+++ b/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/instance/time.st
@@ -1,0 +1,3 @@
+*monticellofiletree-core
+time
+	^ time ifNil:[^Time now]

--- a/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/methodProperties.json
+++ b/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"date" : "PaulDeBruicker 6/28/2012 17:57",
+		"time" : "PaulDeBruicker 6/28/2012 17:58" } }

--- a/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/properties.json
+++ b/repository/MonticelloFileTree-Core.package/MCVersionInfo.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "MCVersionInfo" }


### PR DESCRIPTION
... info

Dale- 

This addresses my question on the list about loading the STIG created Cypress package into Pharo-1.3.

I don't need monticello.meta.  Just this stuff to create a dummy time.  .  

Thanks
