### PR TITLE
Squeak 4.3/4.4 installation currently broken

### DIFF
--- a/doc/SqueakInstall.md
+++ b/doc/SqueakInstall.md
@@ -1,32 +1,8 @@
 ## HOW TO INSTALL in Squeak
 
-#### <a name="clone"></a>Clone FileTree git repository
-
-```shell
-    sudo mkdir /opt/git/
-    sudo chmod og+rw /opt/git/
-    cd /opt/git/
-    git clone -b SQUEAK_BRANCH https://github.com/dalehenrich/filetree.git
-```
-
-Where **SQUEAK_BRANCH**: squeak4.3 (for Squeak4.3 and Squeak4.4).
-
-#### <a name="bootstrap"></a>Bootstrap FileTree into Image
-
 ```Smalltalk
 Installer ss3
-        project: 'FileTree';
-        install: 'MonticelloFileTree-Core.squeak43'.
+    project: 'FileTree';
+    install: 'ConfigurationOfFileTree'.
+((Smalltalk at: #ConfigurationOfFileTree) project version: '1.0') load.
 ```
-
-####  <a name="loadlatest"></a>Load FileTree from Git repository 
-
-Edit path to match `clone directory`:
-
-```Smalltalk
-Installer monticello
-        mc: (MCFileTreeRepository directory:
-                (FileDirectory uri: '/opt/git/filetree/repository/'));
-        install: #('MonticelloFileTree-Core' 'MonticelloFileTree-FileDirectory-Utilities')
-```
-


### PR DESCRIPTION
I needed to make a new filetree repo and so followed the SqueakInstall instructions. The "Load FileTree from Git repository" step fails though. First, I get a nil not understanding `#directoryExists:` because `MCFileTreeFileUtils install` must run first to initialise the `Current` classvar. Next, I get a `#subclassResponsibility` in `MCFileTreeFileUtils >> #directoryExists:`.

What am I missing?
