### PR TITLE
Ston changes

### DIFF
--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/addClassAndMethodDefinitionsFromEntry..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/addClassAndMethodDefinitionsFromEntry..st
@@ -2,12 +2,12 @@ utilities
 addClassAndMethodDefinitionsFromEntry: classEntry
     | classDirectory classPropertiesDict classComment entries methodPropertiesDict |
     classDirectory := self fileUtils directoryFromEntry: classEntry.
-    ((entries := classDirectory entries) detect: [ :entry | entry name = 'properties.json' ] ifNone: [  ])
+    ((entries := classDirectory entries) detect: [:entry | self isPropertyFile: entry] ifNone: [  ])
         ifNotNil: [ :propertyEntry | propertyEntry readStreamDo: [ :fileStream | classPropertiesDict := MCFileTreeJsonParser parseStream: fileStream ] ].
     (entries detect: [ :entry | entry name = 'README.md' ] ifNone: [  ])
         ifNotNil: [ :commentEntry | commentEntry readStreamDo: [ :fileStream | classComment := fileStream contents ] ].
     methodPropertiesDict := Dictionary new.
-    (entries detect: [ :entry | entry name = 'methodProperties.json' ] ifNone: [  ])
+    (entries detect: [ :entry | self isMethodPropertyFile: entry] ifNone: [  ])
         ifNotNil: [ :propertyEntry | 
             propertyEntry
                 readStreamDo: [ :fileStream | 

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/addExtensionClassAndMethodDefinitionsFromEntry..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/addExtensionClassAndMethodDefinitionsFromEntry..st
@@ -2,10 +2,10 @@ utilities
 addExtensionClassAndMethodDefinitionsFromEntry: classEntry
     | classDirectory classPropertiesDict methodPropertiesDict entries |
     classDirectory := self fileUtils directoryFromEntry: classEntry.
-    ((entries := classDirectory entries) detect: [ :entry | entry name = 'properties.json' ] ifNone: [  ])
+    ((entries := classDirectory entries) detect: [ :entry | self isPropertyFile: entry] ifNone: [  ])
         ifNotNil: [ :propertyEntry | propertyEntry readStreamDo: [ :fileStream | classPropertiesDict := MCFileTreeJsonParser parseStream: fileStream ] ].
     methodPropertiesDict := Dictionary new.
-    (entries detect: [ :entry | entry name = 'methodProperties.json' ] ifNone: [  ])
+    (entries detect: [ :entry | self isMethodPropertyFile: entry] ifNone: [  ])
         ifNotNil: [ :propertyEntry | 
             propertyEntry
                 readStreamDo: [ :fileStream | 

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/isMethodPropertyFile..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/isMethodPropertyFile..st
@@ -1,0 +1,3 @@
+private
+isMethodPropertyFile: entry
+	^ entry name = 'methodProperties.ston' or: [ entry name = 'methodProperties.json']

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/isPropertyFile..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressReader.class/instance/isPropertyFile..st
@@ -1,0 +1,3 @@
+private
+isPropertyFile: entry
+	^ entry name = 'properties.ston' or: [ entry name = 'properties.json']

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writeClassDefinition.to..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writeClassDefinition.to..st
@@ -8,10 +8,10 @@ writeClassDefinition: definition to: classPath
     self
         writeInDirectoryName: classPath
         fileName: 'properties'
-        extension: '.json'
+        extension: '.ston'
         visit: [ self writeClassDefinition: definition ].
     self
         writeInDirectoryName: classPath
         fileName: 'methodProperties'
-        extension: '.json'
+        extension: '.ston'
         visit: [ self writeMethodProperties: (self methodDefinitions at: definition className ifAbsent: [ #() ]) ]

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writeDefinitions..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writeDefinitions..st
@@ -49,5 +49,5 @@ writeDefinitions: aCollection
             self
                 writeInDirectoryName: classPath
                 fileName: 'methodProperties'
-                extension: '.json'
+                extension: '.ston'
                 visit: [ self writeMethodProperties: classMethodDefinitions ] ]

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writeExtensionClassDefinition.to..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writeExtensionClassDefinition.to..st
@@ -3,5 +3,5 @@ writeExtensionClassDefinition: definition to: classPath
     self
         writeInDirectoryName: classPath
         fileName: 'properties'
-        extension: '.json'
+        extension: '.ston'
         visit: [ self writeExtensionClassDefinition: definition ]

--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writePropertiesFile.st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/instance/writePropertiesFile.st
@@ -13,5 +13,5 @@ writePropertiesFile
     self
         writeInDirectoryName: '.'
         fileName: 'properties'
-        extension: '.json'
+        extension: '.ston'
         visit: [ Dictionary new writeCypressJsonOn: fileStream ]


### PR DESCRIPTION
I've tried renaming properties.json/methodProperties.json to properties.ston/methodProperties.ston according to the new Cypress spec. It is related to the [Cypress issue 20](https://github.com/CampSmalltalk/Cypress/issues/20).

With some simple tests, I confirmed it does not break anything. We can just switch to the new file names without mess. I hope this fix improves the interchangeability with STIG.

Please consider pulling or cherry picking. If you prefer, I can also send you a good-old change set.
