### PR TITLE
Support non-standard selectors with colons

### DIFF
--- a/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/class/fileNameForSelector..st
+++ b/repository/MonticelloFileTree-Core.package/MCFileTreeStCypressWriter.class/class/fileNameForSelector..st
@@ -1,6 +1,6 @@
 accessing
 fileNameForSelector: selector
-  ^ selector last = $:
+  ^ (selector includes: $:)
     ifTrue: [ 
       selector
         collect: [ :each | 


### PR DESCRIPTION
Selectors don't have to end with a colon if they take arguments. For example, ContextS changes the selector of layered methods to end with the layer name (e.g. `foo:` becomes `foo: (layerA)`). So the translation needs to check if the selector includes colons at all.
