### PR TITLE
Correct ProcessWrapper calling code

### DIFF
--- a/repository/MonticelloFileTree-Git.package/MCFileTreeGitRepository.class/class/runProcessWrapperGitCommand.in..st
+++ b/repository/MonticelloFileTree-Git.package/MCFileTreeGitRepository.class/class/runProcessWrapperGitCommand.in..st
@@ -13,9 +13,26 @@ runProcessWrapperGitCommand: anArrayOfStrings in: aDirectory
 						nextPutAll: '" ' ] ].
 	(Smalltalk at: #ProcessWrapper ifAbsent: [ self error: 'Please load ProcessWrapper' ])
 		ifNotNil: [ :pW | 
-			r := pW new
+			| command |
+			command := pW new
 				useStdout;
-				startWithShellCommand:
-						self gitCommand , ' -C "' , (MCFileTreeFileUtils current directoryPathString: aDirectory) , '" ' , aCommandString;
-				upToEnd ].
+				useStderr;
+				startWithCommand:
+					self gitCommand , ' -C "'
+						,
+							(MCFileTreeFileUtils current directoryPathString: aDirectory)
+						, '" ' , aCommandString;
+				yourself.
+			command waitForExit.
+			self assert: command isRunning not.
+			r := command upToEnd.
+			command exitCode > 0
+				ifTrue:
+					[ 
+					| errorString |
+					errorString := command errorUpToEnd.
+					errorString notEmpty
+						ifTrue:
+							[ MCFileTreeGitError new signal: 'Git error: ' , errorString ].
+					r := '' ] ].
 	^ r


### PR DESCRIPTION
Thanks to Nicolai Hess and Levente Uzoniy, a better (working) way of calling external processes in Windows
